### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - v*.*.*
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,13 @@ on:
       - v*.*.*
 
 permissions:
-  contents: write
+  contents: read
   packages: write
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/dylarcher/verman-cli/security/code-scanning/1](https://github.com/dylarcher/verman-cli/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required for the workflow. The `contents: read` permission is sufficient for most steps, while the `packages: write` permission is needed for publishing to NPM, and the `contents: write` permission is required for creating a GitHub release. This ensures that the workflow has only the permissions it needs to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
